### PR TITLE
Fixed adapter

### DIFF
--- a/app/src/main/java/universe/sk/stportal/ComplaintAdapter.java
+++ b/app/src/main/java/universe/sk/stportal/ComplaintAdapter.java
@@ -7,13 +7,13 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-import java.util.ArrayList;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+
 public class ComplaintAdapter extends ArrayAdapter<Complaint> {
-    Context context;
+    private Context context;
     private ArrayList<Complaint> complaints;
 
     // View lookup cache
@@ -33,27 +33,21 @@ public class ComplaintAdapter extends ArrayAdapter<Complaint> {
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
         // Get the data item for this position
-        Complaint complaint = getItem(position);
+        Complaint complaint = complaints.get(position);
         // Check if an existing view is being reused, otherwise inflate the view
         ViewHolder viewHolder; // view lookup cache stored in tag
-        View result = convertView;
 
         if (convertView == null) {
             viewHolder = new ViewHolder();
             LayoutInflater inflater = LayoutInflater.from(context);
             convertView = inflater.inflate(R.layout.row_complaint, parent, false);
-            System.out.println("convert view inflater1");
             viewHolder.busNum = convertView.findViewById(R.id.tvBusNumber);
             viewHolder.compDate = convertView.findViewById(R.id.tvCompDate);
             viewHolder.compMsg = convertView.findViewById(R.id.tvCompMsg);
 
-            result = convertView;
             convertView.setTag(viewHolder);
-            System.out.println("convert view inflater2");
-        }
-        else {
+        } else {
             viewHolder = (ViewHolder) convertView.getTag();
-            result = convertView;
         }
 
         viewHolder.busNum.setText(complaint.getBusNum());
@@ -61,6 +55,5 @@ public class ComplaintAdapter extends ArrayAdapter<Complaint> {
         viewHolder.compMsg.setText(complaint.getCompMsg());
 
         return convertView; //return the completed view to render on screen
-        //return super.getView(position, convertView, parent);
     }
 }

--- a/app/src/main/java/universe/sk/stportal/ViewComplaintActivity.java
+++ b/app/src/main/java/universe/sk/stportal/ViewComplaintActivity.java
@@ -1,10 +1,12 @@
 package universe.sk.stportal;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
 import android.widget.ListView;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -12,7 +14,6 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -43,21 +44,26 @@ public class ViewComplaintActivity extends AppCompatActivity {
     }
 
     public void loadData() {
+        Handler handler = new Handler() {
+            @Override
+            public void handleMessage(Message msg) {
+                adapter.notifyDataSetChanged();
+            }
+        };
+
         // TODO: LOAD DATA FROM DB
         Runnable runnable = () -> {
             OkHttpClient client = new OkHttpClient.Builder().retryOnConnectionFailure(true).build();
             Request request = new Request.Builder().url(getResources().getString(R.string.base_api_url) + "/complaint").header("Content-Type", "application/json").build();
-
+            complaints.add(new Complaint("kl1234", "23-10-2019", "hello"));
             try {
-                System.out.println("in the try block");
                 Response response = client.newCall(request).execute();
                 JSONArray json_arr = new JSONArray(response.body().string());
                 System.out.println("json_arr: " + json_arr);
                 String bNum, cDate, cMsg;
 //                complaints.clear();
-                complaints.add(new Complaint("kl1234", "23-10-2019", "hello"));
 
-                for (int i=0; i<json_arr.length(); i++) {
+                for (int i = 0; i < json_arr.length(); i++) {
                     JSONObject res = json_arr.getJSONObject(i);
                     System.out.println("res: " + res);
                     bNum = res.getString("busNumber");
@@ -67,15 +73,13 @@ public class ViewComplaintActivity extends AppCompatActivity {
                     complaints.add(i, new Complaint(bNum, cDate, cMsg));
                     System.out.println("Complaints: " + complaints);
                 }
-//                adapter.notifyItemInserted(complaints.size());
-            } catch (JSONException | IOException
-                    e) {
+            } catch (JSONException | IOException e) {
                 e.printStackTrace();
             }
+            handler.sendEmptyMessage(0);
         };
 
         Thread async = new Thread(runnable);
         async.start();
-        adapter.notifyDataSetChanged();
     }
 }


### PR DESCRIPTION
The main issue was you were first trying to call `adapter.notifyDataSetChanged()` from within the thread, which is not allowed because only the thread which created a view can modify it.

Then we moved it to after `async.start()`. The issue now was that `adapter.notifyDataSetChanged()` would get called immediately after the async thread _starts_ when we what we wanted was for it to get called after the async thread had _finished_ .

I added a callback (using `Handler` ) from within the async thread to the main thread and it fixed the problem.
Made some other small changes as well but I don't think they made any difference.